### PR TITLE
A couple changes here if you're interested - gitignore and project vs editor space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
-Binaries/Win64/*.dll
-Binaries/Win64/*.lib
-Binaries/Win64/*.pdb
-Binaries/Win64/*.modules
-Source/DiscordEditor/discord-files/*.cpp
-Source/DiscordEditor/discord-files/*.h
-Intermediate/*
+# exclude Intermediate and Binaries folders
+Intermediate/
+Binaries/*
+
+# exclude DiscordSDK source files
+Source/DiscordEditor/discord-files/*
+
+# Explicitly inlcude the dev note under Binaries
+!Binaries/Win64/put_discord_dll_and_lib_here.txt
+
+# Explicitly inlcude the dev note under Source/DiscordEditor
+!Source/DiscordEditor/discord-files/put_discord_sources_here.txt

--- a/Source/DiscordEditor/Private/DiscordEditor.cpp
+++ b/Source/DiscordEditor/Private/DiscordEditor.cpp
@@ -44,10 +44,10 @@ void FDiscordEditorModule::StartupModule()
 
 	if (SettingsModule != nullptr)
 	{
-		ISettingsSectionPtr SettingsSection = SettingsModule->RegisterSettings("Project", "Plugins", "Discord for Unreal Editor", INVTEXT("Discord for Unreal Editor"), INVTEXT("Configure the Discord for Unreal Editor plug-in."), GetMutableDefault<UDiscordEditorSettings>());
+		ISettingsSectionPtr SettingsSection = SettingsModule->RegisterSettings("Editor", "Plugins", "Discord for Unreal Editor", INVTEXT("Discord for Unreal Editor"), INVTEXT("Configure the Discord for Unreal Editor plug-in."), GetMutableDefault<UDiscordEditorSettings>());
 	}
 
-	UE_LOG(LogDiscordEditor, Log, TEXT("Registered settings \"Project -> Plugins -> Discord for Unreal Editor\""));
+	UE_LOG(LogDiscordEditor, Log, TEXT("Registered settings \"Editor -> Plugins -> Discord for Unreal Editor\""));
 
 	// == Initiate Discord ==
 
@@ -124,10 +124,10 @@ void FDiscordEditorModule::ShutdownModule()
 
 	if (SettingsModule != nullptr)
 	{
-		SettingsModule->UnregisterSettings("Project", "Plugins", "Discord for Unreal Editor");
+		SettingsModule->UnregisterSettings("Editor", "Plugins", "Discord for Unreal Editor");
 	}
 
-	UE_LOG(LogDiscordEditor, Log, TEXT("Unregistered settings \"Project -> Plugins -> Discord for Unreal Editor\""));
+	UE_LOG(LogDiscordEditor, Log, TEXT("Unregistered settings \"Editor -> Plugins -> Discord for Unreal Editor\""));
 }
 
 bool FDiscordEditorModule::Tick(float DeltaTime)

--- a/Source/DiscordEditor/Private/DiscordEditor.cpp
+++ b/Source/DiscordEditor/Private/DiscordEditor.cpp
@@ -12,8 +12,8 @@
 #define LOCTEXT_NAMESPACE "FDiscordEditorModule"
 
 // Create base discord shit
-void* FDiscordEditorModule::DiscordDLLHandle = nullptr;
-discord::Core* core{};
+void *FDiscordEditorModule::DiscordDLLHandle = nullptr;
+discord::Core *core{};
 
 DEFINE_LOG_CATEGORY(LogDiscordEditor);
 
@@ -34,12 +34,13 @@ void FDiscordEditorModule::StartupModule()
 	{
 		UE_LOG(LogDiscordEditor, Fatal, TEXT("Discord DLL could not be loaded, causing a fatal error!"));
 	}
-	else {
+	else
+	{
 		UE_LOG(LogDiscordEditor, Log, TEXT("Discord DLL loaded!"));
 	}
 
 	// == Register settings ==
-	ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings");
+	ISettingsModule *SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings");
 
 	if (SettingsModule != nullptr)
 	{
@@ -79,7 +80,8 @@ void FDiscordEditorModule::StartupModule()
 		{
 			EditingString = FString::Printf(TEXT("Editing a project..."));
 		}
-		else {
+		else
+		{
 			EditingString = FString::Printf(TEXT("Editing %s..."), FApp::GetProjectName());
 		}
 
@@ -90,7 +92,7 @@ void FDiscordEditorModule::StartupModule()
 			FDateTime CurrentTime = FDateTime::UtcNow();
 			activity.GetTimestamps().SetStart(CurrentTime.ToUnixTimestamp());
 		}
-		
+
 		activity.SetState(TCHAR_TO_ANSI(*EditingString));
 
 		if (core != nullptr)
@@ -118,7 +120,7 @@ void FDiscordEditorModule::ShutdownModule()
 	FTSTicker::GetCoreTicker().RemoveTicker(TickDelegateHandle);
 
 	// == Unregister settings ==
-	ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings");
+	ISettingsModule *SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings");
 
 	if (SettingsModule != nullptr)
 	{


### PR DESCRIPTION
I cleaned up the .gitignore with an include/exclude setup.  This future-proofs it a bit and makes the file a bit more readable.

I also did some whitespace cleanup (sorry - I have my editor set up to do this by default, so I just did it) -- the whitespace changes conform to Epic/Unreals code standards in DiscordEditor.cpp now.

The biggest change (and maybe this could be made an option, somehow, is that I changed the scope of the plugin from a per-project settings plugin to an editor wide settings plugin.  The settings now show up in the editor settings and they should be persistent when installed as an engine plugin.

Thanks for putting this together -- it took almost no effort to get it installed and working 👍 